### PR TITLE
Refactor: centralize Spark session configuration

### DIFF
--- a/src/01_ingestion.py
+++ b/src/01_ingestion.py
@@ -2,17 +2,12 @@ import boto3
 import os
 import logging
 from botocore.exceptions import ClientError
+from utils import MINIO_ENDPOINT, ACCESS_KEY, SECRET_KEY, BUCKET_RAW
 
 # --- Configurações ---
-# No mundo real, usaríamos variáveis de ambiente (.env) para esconder as senhas
-# Como é um lab local, vamos deixar explícito por enquanto.
-AWS_ACCESS_KEY = "minioadmin"
-AWS_SECRET_KEY = "minioadmin"
-ENDPOINT_URL = "http://localhost:9000" # Porta da API (não a do console 9001!)
-BUCKET_NAME = "landing-zone"
 LOCAL_DATA_FOLDER = "./data/raw"
 
-# Configuração de Logs (Para parecer profissional)
+# Configuração de Logs
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 def create_bucket_if_not_exists(s3_client, bucket_name):
@@ -40,7 +35,7 @@ def upload_files(s3_client, bucket_name, local_folder):
 
     for file_name in files:
         local_path = os.path.join(local_folder, file_name)
-        s3_path = f"olist/{file_name}" # Organizando dentro de uma "pasta" no bucket
+        s3_path = f"olist/{file_name}"
 
         try:
             logging.info(f"Enviando: {file_name} -> s3://{bucket_name}/{s3_path}")
@@ -54,16 +49,16 @@ def main():
     # 1. Criar o Cliente S3 (Conectando no MinIO)
     s3_client = boto3.client(
         's3',
-        aws_access_key_id=AWS_ACCESS_KEY,
-        aws_secret_access_key=AWS_SECRET_KEY,
-        endpoint_url=ENDPOINT_URL
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        endpoint_url=MINIO_ENDPOINT
     )
 
     # 2. Garantir que o Bucket existe
-    create_bucket_if_not_exists(s3_client, BUCKET_NAME)
+    create_bucket_if_not_exists(s3_client, BUCKET_RAW)
 
     # 3. Fazer o Upload
-    upload_files(s3_client, BUCKET_NAME, LOCAL_DATA_FOLDER)
+    upload_files(s3_client, BUCKET_RAW, LOCAL_DATA_FOLDER)
 
 if __name__ == "__main__":
     main()

--- a/src/03_gold_layer.py
+++ b/src/03_gold_layer.py
@@ -1,49 +1,5 @@
 import sys
-from pyspark.sql import SparkSession
-
-# --- Configurações do MinIO (Origem) ---
-MINIO_ENDPOINT = "http://localhost:9000"
-ACCESS_KEY = "minioadmin"
-SECRET_KEY = "minioadmin"
-BUCKET_SILVER = "processing-zone"
-
-# --- Configurações do Postgres (Destino) ---
-# Atenção: Usando localhost e a porta 5433 que definimos no Docker
-DB_URL = "jdbc:postgresql://localhost:5433/warehouse"
-DB_USER = "admin"
-DB_PASS = "admin"
-DB_DRIVER = "org.postgresql.Driver"
-
-def get_spark_session():
-    """
-    Sessão Spark com Super-Poderes:
-    - Lê S3/MinIO (Drivers Hadoop-AWS)
-    - Escreve JDBC (Driver Postgres)
-    """
-    return (SparkSession.builder
-            .appName("OlistGoldLayer")
-            .master("local[*]")
-            # Carregando Drivers: AWS S3 + PostgreSQL JDBC
-            .config("spark.jars.packages", "org.apache.hadoop:hadoop-aws:3.3.4,com.amazonaws:aws-java-sdk-bundle:1.12.540,org.postgresql:postgresql:42.6.0")
-            
-            # --- Configs MinIO (Igual ao script anterior) ---
-            .config("spark.hadoop.fs.s3a.endpoint", MINIO_ENDPOINT)
-            .config("spark.hadoop.fs.s3a.access.key", ACCESS_KEY)
-            .config("spark.hadoop.fs.s3a.secret.key", SECRET_KEY)
-            .config("spark.hadoop.fs.s3a.path.style.access", "true")
-            .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-            .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
-            .config("spark.hadoop.fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
-            
-            # --- Configs de Estabilidade (Whac-A-Mole) ---
-            .config("spark.hadoop.fs.s3a.connection.establish.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.connection.timeout", "10000")
-            .config("spark.hadoop.fs.s3a.threads.keepalivetime", "60")
-            .config("spark.hadoop.fs.s3a.socket.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.multipart.size", "104857600")
-            .config("spark.hadoop.fs.s3a.multipart.purge.age", "86400")
-            .config("spark.hadoop.fs.s3a.multipart.purge", "false") 
-            .getOrCreate())
+from utils import get_spark_session, DB_URL, DB_USER, DB_PASS, DB_DRIVER, BUCKET_SILVER
 
 def save_to_postgres(df, table_name):
     print(f"--> Escrevendo tabela '{table_name}' no Postgres...")
@@ -63,7 +19,7 @@ def save_to_postgres(df, table_name):
         print(f"!!! Erro ao salvar no banco: {e}")
 
 def main():
-    spark = get_spark_session()
+    spark = get_spark_session("OlistGoldLayer")
     
     # 1. Ler da Silver Layer (Parquet)
     source_path = f"s3a://{BUCKET_SILVER}/orders"
@@ -77,7 +33,6 @@ def main():
         return
 
     # 2. Salvar na Gold Layer (Postgres)
-    # Vamos salvar na tabela 'fact_orders' (Fato Pedidos)
     save_to_postgres(df_silver, "fact_orders")
     
     spark.stop()

--- a/src/04_dim_customers.py
+++ b/src/04_dim_customers.py
@@ -1,39 +1,6 @@
 import sys
-from pyspark.sql import SparkSession
+from utils import get_spark_session, DB_URL, DB_USER, DB_PASS, DB_DRIVER, BUCKET_RAW, BUCKET_SILVER
 
-# --- Configurações ---
-MINIO_ENDPOINT = "http://localhost:9000"
-ACCESS_KEY = "minioadmin"
-SECRET_KEY = "minioadmin"
-BUCKET_RAW = "landing-zone"
-BUCKET_SILVER = "processing-zone"
-
-# Postgres
-DB_URL = "jdbc:postgresql://localhost:5433/warehouse"
-DB_USER = "admin"
-DB_PASS = "admin"
-DB_DRIVER = "org.postgresql.Driver"
-
-def get_spark_session():
-    return (SparkSession.builder
-            .appName("OlistCustomersDim")
-            .master("local[*]")
-            .config("spark.jars.packages", "org.apache.hadoop:hadoop-aws:3.3.4,com.amazonaws:aws-java-sdk-bundle:1.12.540,org.postgresql:postgresql:42.6.0")
-            .config("spark.hadoop.fs.s3a.endpoint", MINIO_ENDPOINT)
-            .config("spark.hadoop.fs.s3a.access.key", ACCESS_KEY)
-            .config("spark.hadoop.fs.s3a.secret.key", SECRET_KEY)
-            .config("spark.hadoop.fs.s3a.path.style.access", "true")
-            .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-            .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
-            .config("spark.hadoop.fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
-            .config("spark.hadoop.fs.s3a.connection.establish.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.connection.timeout", "10000")
-            .config("spark.hadoop.fs.s3a.threads.keepalivetime", "60")
-            .config("spark.hadoop.fs.s3a.socket.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.multipart.size", "104857600")
-            .config("spark.hadoop.fs.s3a.multipart.purge.age", "86400")
-            .config("spark.hadoop.fs.s3a.multipart.purge", "false") 
-            .getOrCreate())
 
 def process_customers(spark):
     print("--> 1. Lendo CSV de Clientes (Raw)...")
@@ -41,8 +8,6 @@ def process_customers(spark):
     
     df = spark.read.csv(path_raw, header=True, inferSchema=True)
     
-    # Pequena transformação: Selecionar e Renomear colunas para ficar bonito
-    # customer_zip_code_prefix -> zip_code
     df_clean = df.selectExpr(
         "customer_id",
         "customer_unique_id",
@@ -69,7 +34,7 @@ def process_customers(spark):
     print("--> Sucesso! Dimensão criada.")
 
 def main():
-    spark = get_spark_session()
+    spark = get_spark_session("OlistCustomersDim")
     process_customers(spark)
     spark.stop()
 

--- a/src/05_dim_products.py
+++ b/src/05_dim_products.py
@@ -1,41 +1,5 @@
 import sys
-from pyspark.sql import SparkSession
-
-# --- Configurações ---
-MINIO_ENDPOINT = "http://localhost:9000"
-ACCESS_KEY = "minioadmin"
-SECRET_KEY = "minioadmin"
-BUCKET_RAW = "landing-zone"
-BUCKET_SILVER = "processing-zone"
-
-# Postgres
-DB_URL = "jdbc:postgresql://localhost:5433/warehouse"
-DB_USER = "admin"
-DB_PASS = "admin"
-DB_DRIVER = "org.postgresql.Driver"
-
-def get_spark_session():
-    # Mantendo a configuração robusta que já validamos
-    return (SparkSession.builder
-            .appName("OlistProductsDim")
-            .master("local[*]")
-            .config("spark.jars.packages", "org.apache.hadoop:hadoop-aws:3.3.4,com.amazonaws:aws-java-sdk-bundle:1.12.540,org.postgresql:postgresql:42.6.0")
-            .config("spark.hadoop.fs.s3a.endpoint", MINIO_ENDPOINT)
-            .config("spark.hadoop.fs.s3a.access.key", ACCESS_KEY)
-            .config("spark.hadoop.fs.s3a.secret.key", SECRET_KEY)
-            .config("spark.hadoop.fs.s3a.path.style.access", "true")
-            .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-            .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
-            .config("spark.hadoop.fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
-            .config("spark.hadoop.fs.s3a.connection.establish.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.connection.timeout", "10000")
-            .config("spark.hadoop.fs.s3a.threads.keepalivetime", "60")
-            .config("spark.hadoop.fs.s3a.socket.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.multipart.size", "104857600")
-            .config("spark.hadoop.fs.s3a.multipart.purge.age", "86400")
-            .config("spark.hadoop.fs.s3a.multipart.purge", "false") 
-            .getOrCreate())
-
+from utils import get_spark_session, BUCKET_RAW, BUCKET_SILVER, DB_URL, DB_USER, DB_PASS, DB_DRIVER
 def process_products(spark):
     print("--> 1. Lendo CSV de Produtos (Raw)...")
     path_raw = f"s3a://{BUCKET_RAW}/olist/olist_products_dataset.csv"
@@ -76,7 +40,7 @@ def process_products(spark):
         print(f"!!! Erro ao salvar no Postgres: {e}")
 
 def main():
-    spark = get_spark_session()
+    spark = get_spark_session("OlistProductsDim")
     process_products(spark)
     spark.stop()
 

--- a/src/06_fact_items.py
+++ b/src/06_fact_items.py
@@ -1,40 +1,6 @@
 import sys
-from pyspark.sql import SparkSession
 from pyspark.sql.functions import col
-
-# --- Configurações ---
-MINIO_ENDPOINT = "http://localhost:9000"
-ACCESS_KEY = "minioadmin"
-SECRET_KEY = "minioadmin"
-BUCKET_RAW = "landing-zone"
-BUCKET_SILVER = "processing-zone"
-
-# Postgres
-DB_URL = "jdbc:postgresql://localhost:5433/warehouse"
-DB_USER = "admin"
-DB_PASS = "admin"
-DB_DRIVER = "org.postgresql.Driver"
-
-def get_spark_session():
-    return (SparkSession.builder
-            .appName("OlistItemsFact")
-            .master("local[*]")
-            .config("spark.jars.packages", "org.apache.hadoop:hadoop-aws:3.3.4,com.amazonaws:aws-java-sdk-bundle:1.12.540,org.postgresql:postgresql:42.6.0")
-            .config("spark.hadoop.fs.s3a.endpoint", MINIO_ENDPOINT)
-            .config("spark.hadoop.fs.s3a.access.key", ACCESS_KEY)
-            .config("spark.hadoop.fs.s3a.secret.key", SECRET_KEY)
-            .config("spark.hadoop.fs.s3a.path.style.access", "true")
-            .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
-            .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
-            .config("spark.hadoop.fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
-            .config("spark.hadoop.fs.s3a.connection.establish.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.connection.timeout", "10000")
-            .config("spark.hadoop.fs.s3a.threads.keepalivetime", "60")
-            .config("spark.hadoop.fs.s3a.socket.timeout", "5000")
-            .config("spark.hadoop.fs.s3a.multipart.size", "104857600")
-            .config("spark.hadoop.fs.s3a.multipart.purge.age", "86400")
-            .config("spark.hadoop.fs.s3a.multipart.purge", "false") 
-            .getOrCreate())
+from utils import get_spark_session, BUCKET_RAW, BUCKET_SILVER, DB_URL, DB_USER, DB_PASS, DB_DRIVER
 
 def process_items(spark):
     print("--> 1. Lendo CSV de Itens (Raw)...")
@@ -77,7 +43,7 @@ def process_items(spark):
         print(f"!!! Erro ao salvar no Postgres: {e}")
 
 def main():
-    spark = get_spark_session()
+    spark = get_spark_session("OlistItemsFact")
     process_items(spark)
     spark.stop()
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,48 @@
+from pyspark.sql import SparkSession
+
+# --- CONSTANTES GERAIS ---
+MINIO_ENDPOINT = "http://localhost:9000"
+ACCESS_KEY = "minioadmin"
+SECRET_KEY = "minioadmin"
+
+# --- BUCKETS ---
+BUCKET_RAW = "landing-zone"
+BUCKET_SILVER = "processing-zone"
+
+# --- BANCO DE DADOS (Postgres) ---
+DB_URL = "jdbc:postgresql://localhost:5433/warehouse"
+DB_USER = "admin"
+DB_PASS = "admin"
+DB_DRIVER = "org.postgresql.Driver"
+
+def get_spark_session(app_name):
+    """
+    Cria uma sessão Spark configurada para S3 (MinIO) e Postgres.
+    Args:
+        app_name (str): Nome da aplicação para os logs.
+    """
+    print(f"🔧 Iniciando Spark App: {app_name}")
+    
+    return (SparkSession.builder
+            .appName(app_name)
+            .master("local[*]")
+            .config("spark.jars.packages", "org.apache.hadoop:hadoop-aws:3.3.4,com.amazonaws:aws-java-sdk-bundle:1.12.540,org.postgresql:postgresql:42.6.0")
+            
+            # --- Configurações MinIO ---
+            .config("spark.hadoop.fs.s3a.endpoint", MINIO_ENDPOINT)
+            .config("spark.hadoop.fs.s3a.access.key", ACCESS_KEY)
+            .config("spark.hadoop.fs.s3a.secret.key", SECRET_KEY)
+            .config("spark.hadoop.fs.s3a.path.style.access", "true")
+            .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+            .config("spark.hadoop.fs.s3a.connection.ssl.enabled", "false")
+            .config("spark.hadoop.fs.s3a.aws.credentials.provider", "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
+            
+            # --- Estabilidade ---
+            .config("spark.hadoop.fs.s3a.connection.establish.timeout", "5000")
+            .config("spark.hadoop.fs.s3a.connection.timeout", "10000")
+            .config("spark.hadoop.fs.s3a.threads.keepalivetime", "60")
+            .config("spark.hadoop.fs.s3a.socket.timeout", "5000")
+            .config("spark.hadoop.fs.s3a.multipart.size", "104857600")
+            .config("spark.hadoop.fs.s3a.multipart.purge.age", "86400")
+            .config("spark.hadoop.fs.s3a.multipart.purge", "false") 
+            .getOrCreate())


### PR DESCRIPTION
## O que foi feito
- Centralização da função `get_spark_session` em `src/utils.py`
- Remoção de código duplicado nos scripts 02–06
- Padronização da inicialização do Spark

## Por que
Evitar duplicação de código e facilitar manutenção futura
(ex: troca de credenciais do MinIO).

Fixes #1
